### PR TITLE
Bump version of protoc-gen-validate library

### DIFF
--- a/go/repositories.bzl
+++ b/go/repositories.bzl
@@ -31,8 +31,8 @@ def go_repos(**kwargs):  # buildifier: disable=function-docstring
     go_repository(
         name = "com_github_envoyproxy_protoc_gen_validate",
         importpath = "github.com/envoyproxy/protoc-gen-validate",
-        sum = "h1:JiO+kJTpmYGjEodY7O1Zk8oZcNz1+f30UtwtXoFUPzE=",
-        version = "v0.6.2",
+        sum = "h1:qcZcULcd/abmQg6dwigimCNEyi4gg31M/xaciQlDml8=",
+        version = "v0.6.7",
     )
 
     go_repository(


### PR DESCRIPTION
Bump version of github.com/envoyproxy/protoc-gen-validate.

Without this update, passing a `go_validate_library` to a `gopath` rule gives the error:

```
foo/bar.proto: is a proto3 file that contains optional fields, but code generator protoc-gen-validate_go_plugin hasn't been updated to support optional fields in proto3. Please ask the owner of this code generator to support proto3 optional.--validate_go_plugin_out: 
```

Adding `--validate_go_plugin_out` to `extra_protoc_args` doesn't fix the issue. But this patch does.